### PR TITLE
Add a new resource (opnsense_firewall_alias_util) for updating alias not managed by terraform

### DIFF
--- a/opnsense/data_firewall_alias.go
+++ b/opnsense/data_firewall_alias.go
@@ -53,7 +53,7 @@ func dataFirewallAliasRead(d *schema.ResourceData, meta interface{}) error {
 	aliasList, err := c.AliasGetList()
 	if err != nil {
 		// temporary fix for the internal error API when we try to get an unreferenced UIID
-		if err.Error() == "Internal Error status code received" {
+		if err.Error() == apiInternalErrorMsg {
 			d.SetId("")
 			return nil
 		}

--- a/opnsense/helpers.go
+++ b/opnsense/helpers.go
@@ -7,6 +7,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+const apiInternalErrorMsg = "Internal Error status code received"
+
 func ValidateUUID() schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(string)

--- a/opnsense/provider.go
+++ b/opnsense/provider.go
@@ -38,9 +38,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"opnsense_wireguard_client": resourceWireGuardClient(),
-			"opnsense_wireguard_server": resourceWireGuardServer(),
-			"opnsense_firewall_alias":   resourceFirewallAlias(),
+			"opnsense_wireguard_client":    resourceWireGuardClient(),
+			"opnsense_wireguard_server":    resourceWireGuardServer(),
+			"opnsense_firewall_alias":      resourceFirewallAlias(),
+			"opnsense_firewall_alias_util": resourceFirewallAliasUtil(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/opnsense/resource_firewall_alias.go
+++ b/opnsense/resource_firewall_alias.go
@@ -86,7 +86,7 @@ func resourceFirewallAliasRead(d *schema.ResourceData, meta interface{}) error {
 	alias, err := c.AliasGet(uuid)
 	if err != nil {
 		// temporary fix for the internal error API when we try to get an unreferenced UIID
-		if err.Error() == "Internal Error status code received" {
+		if err.Error() == apiInternalErrorMsg {
 			d.SetId("")
 			return nil
 		}

--- a/opnsense/resource_firewall_alias_util.go
+++ b/opnsense/resource_firewall_alias_util.go
@@ -1,0 +1,155 @@
+package opnsense
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/kradalby/opnsense-go/opnsense"
+)
+
+func resourceFirewallAliasUtil() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceFirewallAliasUtilCreate,
+		Read:   resourceFirewallAliasUtilRead,
+		Update: resourceFirewallAliasUtilUpdate,
+		Delete: resourceFirewallAliasUtilDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Name of the alias",
+				Required:    true,
+			},
+			"address": {
+				Type:        schema.TypeString,
+				Description: "IP or CIDR address to add in the alias",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func resourceFirewallAliasUtilRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*opnsense.Client)
+
+	name := d.Get("name").(string)
+	alias, err := c.AliasUtilsGet(name)
+
+	if err != nil {
+		d.SetId("")
+		// fix for the internal error API received when we try to get an unreferenced alias
+		if err.Error() == apiInternalErrorMsg {
+			return nil
+		}
+
+		return fmt.Errorf(`error while retrieving the list of address used 
+		 in the alias '%s' with with alias_util : %s`, name, err)
+	}
+
+	// We don't want to retrieved all addresse present in the alias because this resource will manage only one address
+	// instead we just check if the address is present or not in the alias
+	addressInState := d.Get("address").(string)
+	addressFound := false
+
+	if alias.Rows != nil {
+		for _, v := range alias.Rows {
+			if v.Address == addressInState {
+				addressFound = true
+				break
+			}
+		}
+	}
+
+	if addressFound {
+		d.Set("address", addressInState)
+	} else {
+		// address no found in the alias, we tell Terraform that the resource no longer exists
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceFirewallAliasUtilCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*opnsense.Client)
+
+	name := d.Get("name").(string)
+	address := d.Get("address").(string)
+	conf := opnsense.AliasUtilsSet{
+		Address: address,
+	}
+
+	_, err := c.AliasUtilsAdd(name, conf)
+	if err != nil {
+		return fmt.Errorf(`error while creating the resource with alias_util, 
+		 failed to add '%s' from alias '%s' : %s`, conf.Address, name, err)
+	}
+
+	d.SetId(address)
+
+	return resourceFirewallAliasUtilRead(d, meta)
+}
+
+func resourceFirewallAliasUtilUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*opnsense.Client)
+	conf := opnsense.AliasUtilsSet{}
+
+	oldAddress := d.Get("address")
+	newAddress := d.Get("address")
+	oldName := d.Get("name")
+	newName := d.Get("name")
+
+	if d.HasChange("name") {
+		oldName, newName = d.GetChange("name")
+	}
+
+	if d.HasChange("address") {
+		oldAddress, newAddress = d.GetChange("address")
+	}
+
+	// We always try to add the new address before removing the previous one because this
+	// could result in an unsafe state where  we have deleted the address without added the new one
+	conf.Address = newAddress.(string)
+	_, err := c.AliasUtilsAdd(newName.(string), conf)
+
+	if err != nil {
+		return fmt.Errorf(`error while updating an alias with alias_util,
+		 failed to add '%s' in alias '%s' : %s`, conf.Address, newName.(string), err)
+	}
+
+	conf.Address = oldAddress.(string)
+	_, err = c.AliasUtilsDel(oldName.(string), conf)
+
+	if err != nil {
+		return fmt.Errorf(`error while updating an alias with alias_util,
+		 failed to remove '%s' in alias '%s' : %s`, conf.Address, oldName.(string), err)
+	}
+
+	d.SetId(newAddress.(string))
+
+	return resourceFirewallAliasUtilRead(d, meta)
+}
+
+func resourceFirewallAliasUtilDelete(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*opnsense.Client)
+
+	name := d.Get("name").(string)
+	conf := opnsense.AliasUtilsSet{
+		Address: d.Get("address").(string),
+	}
+
+	_, err := c.AliasUtilsDel(name, conf)
+	if err != nil {
+		// normally we should handle here the case when the API return an error and check if the
+		// resource might already be destroyed (manually for example) but the API doesn't return
+		// an error when we try to delete a non existing address in the alias so we can skip
+		// this logic and always return the error send by opnsense
+		return fmt.Errorf(`error while deleting the resource with alias_util,
+		 failed to remove '%s' from alias '%s' : %s`, conf.Address, name, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This new resource allows partial provisioning of an alias by adding or removing atomically addresses from an existing alias using the alias_util endpoint. In order to function properly, this resource only tracks the addresses entered in the tf file, so if an alias contains more elements, they will not be taken into account when changes are detected in the state

ex:

variable "subnet" {
  description = "List of subnet to add in the master alias"
  type        = set(string)
  default     = ["1.1.1.1", "1.1.1.2"]
}

resource "opnsense_firewall_alias_util" "test" {
  for_each = var.subnet
  name     = "MASTER"
  address  = each.value
}

this exemple will add 2 address in the MASTER alias, and if we destroy this resource, only the 2 address will be removed, keeping all the other addresses present in the MASTER alias